### PR TITLE
Remove support feed signatures

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
 support/targets-v2.json text eol=lf
-support/targets-v2.sig text eol=lf

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains the device-specific native side of
 - the app-domain CVE-2026-43499 exploit source and compiled payload;
 - the app bootstrap helper source;
 - the verified KernelSU late-load build artifacts;
-- the Ed25519-signed support feed consumed by the application.
+- the support feed consumed by the application.
 
 It intentionally does not contain Android application source code.
 
@@ -32,14 +32,12 @@ display ID, SDK, ABI, and page size remain part of automatic profile selection.
 The port is based on the exploit source published at
 <https://github.com/NebuSec/CyberMeowfia/tree/main/IonStack/CVE-2026-43499/exploit>.
 
-## Feed integrity
+## Feed delivery
 
-`support/targets-v2.json` is signed with Ed25519. Root My Galaxy resolves the
-payload repository's current commit first and fetches the manifest, signature,
-and every artifact from that immutable commit. Per-artifact SHA-256 fields are
-not part of schema version 2.
-
-The signing private key is not stored in this repository.
+Root My Galaxy resolves the payload repository's current commit first and
+fetches `support/targets-v2.json` and every artifact from that immutable commit.
+Per-artifact SHA-256 fields and manifest signatures are not part of schema
+version 2.
 
 ## Build
 

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -282,9 +282,8 @@ depends on symbols trimmed from the target export table.
 Add an exact entry to `support/targets-v2.json`, including the target's literal
 `uname -r` value as `kernelRelease` and complete `/proc/version` string as
 `kernelVersion`. Do not invent a suffix when a vendor kernel exposes a short
-release string. Update artifact sizes and sign the final JSON with the existing
-Ed25519 manifest key. Verify the signature with the public key compiled into
-Root My Galaxy. Never add the private key to the repository.
+release string. Update artifact sizes, validate the final JSON, and confirm that
+Root My Galaxy can parse the profile before publishing it.
 
 ## 9. Cleanup policy
 

--- a/docs/SM-A155N-A155NKSS6BYH1.md
+++ b/docs/SM-A155N-A155NKSS6BYH1.md
@@ -242,5 +242,5 @@ The standalone KO reports exactly:
 ```
 
 The `ksud` binary embeds that KO as `android12-5.10_kernelsu.ko`. This exact
-profile is included in the signed support feed, but hardware execution remains
+profile is included in the support feed, but hardware execution remains
 unverified until an `SM-A155N` running `A155NKSS6BYH1` is available.

--- a/support/targets-v2.sig
+++ b/support/targets-v2.sig
@@ -1,1 +1,0 @@
-rV/lZ1k3ost7VQlUexRQo1QBco/828pTpzhjFjRDhHlbTsy/2+yGVdXHcqjMVJshYOmZGD0xjj4AOC2iSCy2AQ==


### PR DESCRIPTION
## What changed
- Removed `support/targets-v2.sig` and its Git attribute.
- Removed the Ed25519 signing procedure from repository documentation.
- Documented the unsigned, commit-pinned feed workflow.

## Why
Contributors can now update the support feed without access to a private signing key.

## Checks
- Parsed `support/targets-v2.json` successfully.
- Confirmed the published feed still contains only `pa3q-S938NKSUACZF1`.
- Ran `git diff --check`.