### PR TITLE
Correct S928U firmware build ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It intentionally does not contain Android application source code.
 | --- | --- | --- | --- | --- |
 | `pa3q-S938NKSUACZF1` | Galaxy S25 Ultra `SM-S938N` | `BP4A.251205.006.S938NKSUACZF1` | `android15-6.6` | Device-tested |
 | `pa3q-S9380ZHUBCZF1` | Galaxy S25 Ultra `SM-S9380` | `BP4A.251205.006.S9380ZHUBCZF1` | `android15-6.6` | Device-tested |
-| `e3q-S928USQS6DZF2` | Galaxy S24 Ultra `SM-S928U/SM-S928U1` (Snapdragon 8 Gen 3) | `UP1A.231005.007.S928USQS6DZF2` | `6.1.145-android14-11-33419968-abS928USQS6DZF2` | Thanks to fusiondrive |
+| `e3q-S928USQS6DZF2` | Galaxy S24 Ultra `SM-S928U/SM-S928U1` (Snapdragon 8 Gen 3) | `BP4A.251205.007.S928USQS6DZF2` | `6.1.145-android14-11-33419968-abS928USQS6DZF2` | Thanks to fusiondrive |
 
 Profiles are exact-firmware profiles. A matching model with a different build
 is not equivalent and must be ported separately.

--- a/support/targets-v2.json
+++ b/support/targets-v2.json
@@ -57,7 +57,7 @@
       "kernelRelease": "6.1.145-android14-11-33419968-abS928USQS6DZF2",
       "kernelVersion": "Linux version 6.1.145-android14-11-33419968-abS928USQS6DZF2 (build-user@build-host) (Android (10087095, +pgo, +bolt, +lto, -mlgo, based on r487747c) clang version 17.0.2 (https://android.googlesource.com/toolchain/llvm-project d9f89f4d16663d5012e5c09495f3b30ece3d2362), LLD 17.0.2) #1 SMP PREEMPT Tue Jun  9 08:23:14 UTC 2026",
       "kernelBuildVersion": "#1 SMP PREEMPT Tue Jun  9 08:23:14 UTC 2026",
-      "buildDisplay": "UP1A.231005.007.S928USQS6DZF2",
+      "buildDisplay": "BP4A.251205.007.S928USQS6DZF2",
       "buildFingerprint": "samsung/e3qsqw/e3q:14/UP1A.231005.007/S928USQS6DZF2:user/release-keys",
       "sdk": 34,
       "abi": "arm64-v8a",


### PR DESCRIPTION
Correct the S928U/S928U1 firmware display ID in the supported-profiles table from `UP1A.231005.007` to `BP4A.251205.007`.\n\nThis PR intentionally changes only the README build string; the remaining profile work is still WIP.