### PR TITLE
Add shared S25 payload manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,23 +11,20 @@ This repository contains the device-specific native side of
 
 It intentionally does not contain Android application source code.
 
-## Supported profiles
+## Supported payloads
 
-| Profile | Device | Firmware | Kernel/KMI | Status |
-| --- | --- | --- | --- | --- |
-| `pa3q-S938NKSUACZF1` | Galaxy S25 Ultra `SM-S938N` | `BP4A.251205.006.S938NKSUACZF1` | `android15-6.6` | Device-tested |
-| `pa3q-S9380ZHUBCZF1` | Galaxy S25 Ultra `SM-S9380` | `BP4A.251205.006.S9380ZHUBCZF1` | `android15-6.6` | Device-tested |
-| `e3q-S928USQS6DZF2` | Galaxy S24 Ultra `SM-S928U/SM-S928U1` (Snapdragon 8 Gen 3) | `BP4A.251205.006.S928USQS6DZF2` | `6.1.145-android14-11-33419968-abS928USQS6DZF2` | Hardware debugging in progress |
-| `essi-A566EXXSCCZG6` | Galaxy A56 5G `SM-A566E` | `BP4A.251205.006.A566EXXSCCZG6` | `6.6.102-android15-8-abA566EXXSCCZG6-4k` | Device-tested |
+| Payload | Compatible devices/builds | Kernel/KMI | Status |
+| --- | --- | --- | --- |
+| `galaxy-s25-series-2026-06-07` | Galaxy S25, S25+, S25 Edge, and S25 Ultra regional models on June/July 2026 security patches | `android15-6.6` / 4K | Device-tested |
+| `e3q-S928USQS6DZF2` | Galaxy S24 Ultra `SM-S928U`, exact `S928USQS6DZF2` build | `6.1.145-android14-11-33419968-abS928USQS6DZF2` | Hardware debugging in progress |
+| `essi-A566EXXSCCZG6` | Galaxy A56 5G `SM-A566E`, exact `A566EXXSCCZG6` build | `6.6.102-android15-8-abA566EXXSCCZG6-4k` | Device-tested |
 
-Profiles are exact-firmware profiles. A matching model with a different build
-is not equivalent and must be ported separately.
-
-Root My Galaxy requires both the exact `uname -r` value in `kernelRelease` and
-the complete `/proc/version` value in `kernelVersion`. This distinguishes
-vendor kernels that expose the same release string but were linked from
-different builds. Model and device fields are descriptive metadata; build
-display ID, SDK, ABI, and page size remain part of automatic profile selection.
+Schema version 3 keeps each exploit and KernelSU artifact once and places its
+regional model list under `compatibility.supportedDevices`. Exact-build
+payloads still require their literal kernel release, kernel build version, and
+display build. The shared S25 payload instead requires a listed S25 model, the
+6.6/android15-8/4K kernel family, SDK 36, and a June or July 2026 security
+patch. See [`support/README.md`](support/README.md) for the matching rules.
 
 The port is based on the exploit source published at
 <https://github.com/NebuSec/CyberMeowfia/tree/main/IonStack/CVE-2026-43499/exploit>.
@@ -35,9 +32,9 @@ The port is based on the exploit source published at
 ## Feed delivery
 
 Root My Galaxy resolves the payload repository's current commit first and
-fetches `support/targets-v2.json` and every artifact from that immutable commit.
-Per-artifact SHA-256 fields and manifest signatures are not part of schema
-version 2.
+fetches `support/targets-v3.json` and every artifact from that immutable
+commit. Per-artifact SHA-256 fields and manifest signatures are not part of
+schema version 3. `targets-v2.json` is retained for released 0.2.3 clients.
 
 ## Build
 

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -431,11 +431,15 @@ depends on symbols trimmed from the target export table.
 
 ## 8. Publish the support feed
 
-Add an exact entry to `support/targets-v2.json`, including the target's literal
-`uname -r` value as `kernelRelease` and complete `/proc/version` string as
-`kernelVersion`. Do not invent a suffix when a vendor kernel exposes a short
-release string. Update artifact sizes, validate the final JSON, and confirm that
-Root My Galaxy can parse the profile before publishing it.
+Add the artifact once to `support/targets-v3.json`, then list every verified
+regional model that uses the same binary under
+`compatibility.supportedDevices`. Keep exact firmware constraints for a normal
+port: literal `uname -r`, complete `uname -v`, display build, SDK, ABI, and page
+size. Use a bounded kernel-family rule or security-patch-month list only after
+the same artifact has been validated across that complete range. Update
+artifact sizes, validate the final JSON, and confirm that Root My Galaxy can
+parse the payload before publishing it. The schema fields and empty-list
+semantics are documented in [`../support/README.md`](../support/README.md).
 
 ## 9. Cleanup policy
 

--- a/support/README.md
+++ b/support/README.md
@@ -1,0 +1,22 @@
+# Support feed schema
+
+`targets-v3.json` separates downloadable payloads from compatible devices. A
+single payload entry owns one exploit and one KernelSU artifact, while
+`compatibility.supportedDevices` lists every regional model that can use those
+same binaries.
+
+Automatic selection requires all of these checks to pass:
+
+- manufacturer and an exact `Build.MODEL` entry in `supportedDevices`;
+- kernel release rule and, when present, an exact kernel build version;
+- exact build display and/or security-patch month when either list is present;
+- SDK, primary ABI, and page size.
+
+`kernelRelease.exact` takes precedence when it is non-empty. Otherwise
+`prefix`, `contains`, and `suffix` must all be non-empty and all three bounds
+must match. An empty `kernelBuildVersions`, `buildDisplays`, or
+`securityPatchMonths` array means that field does not further restrict the
+payload.
+
+`targets-v2.json` remains unchanged for released 0.2.3 clients. New clients
+read only schema version 3.

--- a/support/targets-v3.json
+++ b/support/targets-v3.json
@@ -1,0 +1,132 @@
+{
+  "schemaVersion": 3,
+  "payloads": [
+    {
+      "payloadId": "galaxy-s25-series-2026-06-07",
+      "displayName": "Galaxy S25 series · June/July 2026",
+      "compatibility": {
+        "manufacturer": "samsung",
+        "supportedDevices": [
+          { "name": "Galaxy S25", "model": "SM-S9310", "region": "Greater China" },
+          { "name": "Galaxy S25", "model": "SM-S931B", "region": "International" },
+          { "name": "Galaxy S25", "model": "SM-S931N", "region": "South Korea" },
+          { "name": "Galaxy S25", "model": "SM-S931Q", "region": "Japan" },
+          { "name": "Galaxy S25", "model": "SM-S931U", "region": "United States" },
+          { "name": "Galaxy S25", "model": "SM-S931U1", "region": "United States" },
+          { "name": "Galaxy S25", "model": "SM-S931W", "region": "Canada" },
+          { "name": "Galaxy S25", "model": "SM-S931Z", "region": "Japan" },
+          { "name": "Galaxy S25", "model": "SC-51F", "region": "Japan" },
+          { "name": "Galaxy S25", "model": "SCG31", "region": "Japan" },
+          { "name": "Galaxy S25+", "model": "SM-S9360", "region": "Greater China" },
+          { "name": "Galaxy S25+", "model": "SM-S936B", "region": "International" },
+          { "name": "Galaxy S25+", "model": "SM-S936N", "region": "South Korea" },
+          { "name": "Galaxy S25+", "model": "SM-S936U", "region": "United States" },
+          { "name": "Galaxy S25+", "model": "SM-S936U1", "region": "United States" },
+          { "name": "Galaxy S25+", "model": "SM-S936W", "region": "Canada" },
+          { "name": "Galaxy S25 Edge", "model": "SM-S9370", "region": "Greater China" },
+          { "name": "Galaxy S25 Edge", "model": "SM-S937B", "region": "International" },
+          { "name": "Galaxy S25 Edge", "model": "SM-S937N", "region": "South Korea" },
+          { "name": "Galaxy S25 Edge", "model": "SM-S937U", "region": "United States" },
+          { "name": "Galaxy S25 Edge", "model": "SM-S937U1", "region": "United States" },
+          { "name": "Galaxy S25 Edge", "model": "SM-S937W", "region": "Canada" },
+          { "name": "Galaxy S25 Ultra", "model": "SM-S9380", "region": "Greater China" },
+          { "name": "Galaxy S25 Ultra", "model": "SM-S938B", "region": "International" },
+          { "name": "Galaxy S25 Ultra", "model": "SM-S938N", "region": "South Korea" },
+          { "name": "Galaxy S25 Ultra", "model": "SM-S938Q", "region": "Japan" },
+          { "name": "Galaxy S25 Ultra", "model": "SM-S938U", "region": "United States" },
+          { "name": "Galaxy S25 Ultra", "model": "SM-S938U1", "region": "United States" },
+          { "name": "Galaxy S25 Ultra", "model": "SM-S938W", "region": "Canada" },
+          { "name": "Galaxy S25 Ultra", "model": "SM-S938Z", "region": "Japan" },
+          { "name": "Galaxy S25 Ultra", "model": "SC-52F", "region": "Japan" },
+          { "name": "Galaxy S25 Ultra", "model": "SCG32", "region": "Japan" }
+        ],
+        "kernelRelease": {
+          "exact": [],
+          "prefix": "6.6.",
+          "contains": "-android15-8-",
+          "suffix": "-4k"
+        },
+        "kernelBuildVersions": [],
+        "buildDisplays": [],
+        "securityPatchMonths": ["2026-06", "2026-07"],
+        "sdk": 36,
+        "abi": "arm64-v8a",
+        "pageSize": 4096
+      },
+      "exploit": {
+        "url": "https://raw.githubusercontent.com/BuSung-dev/Root-My-Galaxy-Payloads/main/artifacts/pa3q-S938NKSUACZF1/cve-2026-43499-app.so",
+        "size": 104128
+      },
+      "kernelsu": {
+        "url": "https://raw.githubusercontent.com/BuSung-dev/Root-My-Galaxy-Payloads/main/kernelsu/ksud-s25u-kdp",
+        "size": 6407096,
+        "kmi": "android15-6.6",
+        "managerPackage": "me.weishu.kernelsu"
+      }
+    },
+    {
+      "payloadId": "e3q-S928USQS6DZF2",
+      "displayName": "Galaxy S24 Ultra · S928USQS6DZF2",
+      "compatibility": {
+        "manufacturer": "samsung",
+        "supportedDevices": [
+          { "name": "Galaxy S24 Ultra", "model": "SM-S928U", "region": "United States" }
+        ],
+        "kernelRelease": {
+          "exact": ["6.1.145-android14-11-33419968-abS928USQS6DZF2"],
+          "prefix": "",
+          "contains": "",
+          "suffix": ""
+        },
+        "kernelBuildVersions": ["#1 SMP PREEMPT Tue Jun  9 08:23:14 UTC 2026"],
+        "buildDisplays": ["BP4A.251205.006.S928USQS6DZF2"],
+        "securityPatchMonths": [],
+        "sdk": 36,
+        "abi": "arm64-v8a",
+        "pageSize": 4096
+      },
+      "exploit": {
+        "url": "https://raw.githubusercontent.com/BuSung-dev/Root-My-Galaxy-Payloads/main/artifacts/e3q-S928USQS6DZF2/cve-2026-43499-app.so",
+        "size": 104128
+      },
+      "kernelsu": {
+        "url": "https://raw.githubusercontent.com/BuSung-dev/Root-My-Galaxy-Payloads/main/kernelsu/ksud-e3q-S928USQS6DZF2-kdp",
+        "size": 4726416,
+        "kmi": "android14-6.1",
+        "managerPackage": "me.weishu.kernelsu"
+      }
+    },
+    {
+      "payloadId": "essi-A566EXXSCCZG6",
+      "displayName": "Galaxy A56 5G · A566EXXSCCZG6",
+      "compatibility": {
+        "manufacturer": "samsung",
+        "supportedDevices": [
+          { "name": "Galaxy A56 5G", "model": "SM-A566E", "region": "International" }
+        ],
+        "kernelRelease": {
+          "exact": ["6.6.102-android15-8-abA566EXXSCCZG6-4k"],
+          "prefix": "",
+          "contains": "",
+          "suffix": ""
+        },
+        "kernelBuildVersions": ["#1 SMP PREEMPT Thu Jul  9 11:02:17 UTC 2026"],
+        "buildDisplays": ["BP4A.251205.006.A566EXXSCCZG6"],
+        "securityPatchMonths": [],
+        "sdk": 36,
+        "abi": "arm64-v8a",
+        "pageSize": 4096
+      },
+      "exploit": {
+        "url": "https://raw.githubusercontent.com/BuSung-dev/Root-My-Galaxy-Payloads/main/artifacts/essi-A566EXXSCCZG6/cve-2026-43499-app.so",
+        "size": 104128
+      },
+      "kernelsu": {
+        "url": "https://raw.githubusercontent.com/BuSung-dev/Root-My-Galaxy-Payloads/main/kernelsu/ksud-A566EXXSCCZG6-kdp",
+        "size": 4765336,
+        "kmi": "android15-6.6",
+        "managerPackage": "me.weishu.kernelsu"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What changed
- add support manifest schema v3 with one exploit/KernelSU pair per payload
- group 32 regional Galaxy S25, S25+, S25 Edge, and S25 Ultra models under one shared June/July 2026 payload
- preserve exact matching for the existing S24 Ultra and A56 payloads
- retain `targets-v2.json` unchanged for released 0.2.3 clients
- document schema v3 and contributor porting rules

## Why
The same S25 native payload is working across the S25 family and regional variants on the June and July 2026 patches. The old schema duplicated artifacts for every exact firmware profile.

## Validation
- parsed schema v3 successfully
- confirmed 3 unique payload IDs and 32 unique S25 model IDs
- confirmed every artifact URL maps to a tracked file with the declared size
- confirmed `targets-v2.json` is unchanged
- `git diff --check`

The Root My Galaxy 0.2.4 app PR should be merged after this payload PR.
