### PR TITLE
Simplify the v3 payload manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,10 @@ It intentionally does not contain Android application source code.
 | `e3q-S928USQS6DZF2` | Galaxy S24 Ultra `SM-S928U`, exact `S928USQS6DZF2` build | `6.1.145-android14-11-33419968-abS928USQS6DZF2` | Hardware debugging in progress |
 | `essi-A566EXXSCCZG6` | Galaxy A56 5G `SM-A566E`, exact `A566EXXSCCZG6` build | `6.6.102-android15-8-abA566EXXSCCZG6-4k` | Device-tested |
 
-Schema version 3 keeps each exploit and KernelSU artifact once and places its
-regional model list under `compatibility.supportedDevices`. Exact-build
-payloads still require their literal kernel release, kernel build version, and
-display build. The shared S25 payload instead requires a listed S25 model, the
-6.6/android15-8/4K kernel family, SDK 36, and a June or July 2026 security
-patch. See [`support/README.md`](support/README.md) for the matching rules.
+Schema version 3 keeps each exploit and KernelSU artifact once. Its flat
+`models` array lists compatible regional models, while `builds` or
+`securityPatchMonths` limits the verified firmware range. See
+[`support/README.md`](support/README.md) for the matching rules.
 
 The port is based on the exploit source published at
 <https://github.com/NebuSec/CyberMeowfia/tree/main/IonStack/CVE-2026-43499/exploit>.

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -431,15 +431,14 @@ depends on symbols trimmed from the target export table.
 
 ## 8. Publish the support feed
 
-Add the artifact once to `support/targets-v3.json`, then list every verified
-regional model that uses the same binary under
-`compatibility.supportedDevices`. Keep exact firmware constraints for a normal
-port: literal `uname -r`, complete `uname -v`, display build, SDK, ABI, and page
-size. Use a bounded kernel-family rule or security-patch-month list only after
-the same artifact has been validated across that complete range. Update
-artifact sizes, validate the final JSON, and confirm that Root My Galaxy can
-parse the payload before publishing it. The schema fields and empty-list
-semantics are documented in [`../support/README.md`](../support/README.md).
+Add the artifact once to `support/targets-v3.json`, then add every verified
+regional `Build.MODEL` value to `models`. Use `builds` for an exact-build port.
+Use `securityPatchMonths` only after the same artifact has been validated on
+every listed model across that complete month range. Kernel analysis and exact
+`uname` evidence belong in the target source and porting notes, not the runtime
+support manifest. Update artifact sizes, validate the final JSON, and confirm
+that Root My Galaxy can parse it before publishing. The minimal fields are
+documented in [`../support/README.md`](../support/README.md).
 
 ## 9. Cleanup policy
 

--- a/support/README.md
+++ b/support/README.md
@@ -1,22 +1,20 @@
 # Support feed schema
 
-`targets-v3.json` separates downloadable payloads from compatible devices. A
-single payload entry owns one exploit and one KernelSU artifact, while
-`compatibility.supportedDevices` lists every regional model that can use those
-same binaries.
+`targets-v3.json` keeps one entry for each shared exploit and KernelSU payload.
+`models` lists every model that can use those exact binaries.
 
-Automatic selection requires all of these checks to pass:
+Each entry contains only:
 
-- manufacturer and an exact `Build.MODEL` entry in `supportedDevices`;
-- kernel release rule and, when present, an exact kernel build version;
-- exact build display and/or security-patch month when either list is present;
-- SDK, primary ABI, and page size.
+- `payloadId` and `displayName`;
+- one or more exact `Build.MODEL` values in `models`;
+- either exact Android build displays in `builds` or verified `YYYY-MM` values
+  in `securityPatchMonths`;
+- `url` and `size` for the exploit and KernelSU artifacts.
 
-`kernelRelease.exact` takes precedence when it is non-empty. Otherwise
-`prefix`, `contains`, and `suffix` must all be non-empty and all three bounds
-must match. An empty `kernelBuildVersions`, `buildDisplays`, or
-`securityPatchMonths` array means that field does not further restrict the
-payload.
+Automatic selection requires a model match and all declared build constraints
+to match. Omit `builds` when the payload is validated for every build in the
+listed security-patch months. Omit `securityPatchMonths` for an exact-build
+payload. At least one of these two constraints is required.
 
 `targets-v2.json` remains unchanged for released 0.2.3 clients. New clients
 read only schema version 3.

--- a/support/targets-v3.json
+++ b/support/targets-v3.json
@@ -4,128 +4,76 @@
     {
       "payloadId": "galaxy-s25-series-2026-06-07",
       "displayName": "Galaxy S25 series | June/July 2026",
-      "compatibility": {
-        "manufacturer": "samsung",
-        "supportedDevices": [
-          { "name": "Galaxy S25", "model": "SM-S9310", "region": "Greater China" },
-          { "name": "Galaxy S25", "model": "SM-S931B", "region": "International" },
-          { "name": "Galaxy S25", "model": "SM-S931N", "region": "South Korea" },
-          { "name": "Galaxy S25", "model": "SM-S931Q", "region": "Japan" },
-          { "name": "Galaxy S25", "model": "SM-S931U", "region": "United States" },
-          { "name": "Galaxy S25", "model": "SM-S931U1", "region": "United States" },
-          { "name": "Galaxy S25", "model": "SM-S931W", "region": "Canada" },
-          { "name": "Galaxy S25", "model": "SM-S931Z", "region": "Japan" },
-          { "name": "Galaxy S25", "model": "SC-51F", "region": "Japan" },
-          { "name": "Galaxy S25", "model": "SCG31", "region": "Japan" },
-          { "name": "Galaxy S25+", "model": "SM-S9360", "region": "Greater China" },
-          { "name": "Galaxy S25+", "model": "SM-S936B", "region": "International" },
-          { "name": "Galaxy S25+", "model": "SM-S936N", "region": "South Korea" },
-          { "name": "Galaxy S25+", "model": "SM-S936U", "region": "United States" },
-          { "name": "Galaxy S25+", "model": "SM-S936U1", "region": "United States" },
-          { "name": "Galaxy S25+", "model": "SM-S936W", "region": "Canada" },
-          { "name": "Galaxy S25 Edge", "model": "SM-S9370", "region": "Greater China" },
-          { "name": "Galaxy S25 Edge", "model": "SM-S937B", "region": "International" },
-          { "name": "Galaxy S25 Edge", "model": "SM-S937N", "region": "South Korea" },
-          { "name": "Galaxy S25 Edge", "model": "SM-S937U", "region": "United States" },
-          { "name": "Galaxy S25 Edge", "model": "SM-S937U1", "region": "United States" },
-          { "name": "Galaxy S25 Edge", "model": "SM-S937W", "region": "Canada" },
-          { "name": "Galaxy S25 Ultra", "model": "SM-S9380", "region": "Greater China" },
-          { "name": "Galaxy S25 Ultra", "model": "SM-S938B", "region": "International" },
-          { "name": "Galaxy S25 Ultra", "model": "SM-S938N", "region": "South Korea" },
-          { "name": "Galaxy S25 Ultra", "model": "SM-S938Q", "region": "Japan" },
-          { "name": "Galaxy S25 Ultra", "model": "SM-S938U", "region": "United States" },
-          { "name": "Galaxy S25 Ultra", "model": "SM-S938U1", "region": "United States" },
-          { "name": "Galaxy S25 Ultra", "model": "SM-S938W", "region": "Canada" },
-          { "name": "Galaxy S25 Ultra", "model": "SM-S938Z", "region": "Japan" },
-          { "name": "Galaxy S25 Ultra", "model": "SC-52F", "region": "Japan" },
-          { "name": "Galaxy S25 Ultra", "model": "SCG32", "region": "Japan" }
-        ],
-        "kernelRelease": {
-          "exact": [],
-          "prefix": "6.6.",
-          "contains": "-android15-8-",
-          "suffix": "-4k"
-        },
-        "kernelBuildVersions": [],
-        "buildDisplays": [],
-        "securityPatchMonths": ["2026-06", "2026-07"],
-        "sdk": 36,
-        "abi": "arm64-v8a",
-        "pageSize": 4096
-      },
+      "models": [
+        "SM-S9310",
+        "SM-S931B",
+        "SM-S931N",
+        "SM-S931Q",
+        "SM-S931U",
+        "SM-S931U1",
+        "SM-S931W",
+        "SM-S931Z",
+        "SC-51F",
+        "SCG31",
+        "SM-S9360",
+        "SM-S936B",
+        "SM-S936N",
+        "SM-S936U",
+        "SM-S936U1",
+        "SM-S936W",
+        "SM-S9370",
+        "SM-S937B",
+        "SM-S937N",
+        "SM-S937U",
+        "SM-S937U1",
+        "SM-S937W",
+        "SM-S9380",
+        "SM-S938B",
+        "SM-S938N",
+        "SM-S938Q",
+        "SM-S938U",
+        "SM-S938U1",
+        "SM-S938W",
+        "SM-S938Z",
+        "SC-52F",
+        "SCG32"
+      ],
+      "securityPatchMonths": ["2026-06", "2026-07"],
       "exploit": {
         "url": "https://raw.githubusercontent.com/BuSung-dev/Root-My-Galaxy-Payloads/main/artifacts/pa3q-S938NKSUACZF1/cve-2026-43499-app.so",
         "size": 104128
       },
       "kernelsu": {
         "url": "https://raw.githubusercontent.com/BuSung-dev/Root-My-Galaxy-Payloads/main/kernelsu/ksud-s25u-kdp",
-        "size": 6407096,
-        "kmi": "android15-6.6",
-        "managerPackage": "me.weishu.kernelsu"
+        "size": 6407096
       }
     },
     {
       "payloadId": "e3q-S928USQS6DZF2",
       "displayName": "Galaxy S24 Ultra | S928USQS6DZF2",
-      "compatibility": {
-        "manufacturer": "samsung",
-        "supportedDevices": [
-          { "name": "Galaxy S24 Ultra", "model": "SM-S928U", "region": "United States" }
-        ],
-        "kernelRelease": {
-          "exact": ["6.1.145-android14-11-33419968-abS928USQS6DZF2"],
-          "prefix": "",
-          "contains": "",
-          "suffix": ""
-        },
-        "kernelBuildVersions": ["#1 SMP PREEMPT Tue Jun  9 08:23:14 UTC 2026"],
-        "buildDisplays": ["BP4A.251205.006.S928USQS6DZF2"],
-        "securityPatchMonths": [],
-        "sdk": 36,
-        "abi": "arm64-v8a",
-        "pageSize": 4096
-      },
+      "models": ["SM-S928U"],
+      "builds": ["BP4A.251205.006.S928USQS6DZF2"],
       "exploit": {
         "url": "https://raw.githubusercontent.com/BuSung-dev/Root-My-Galaxy-Payloads/main/artifacts/e3q-S928USQS6DZF2/cve-2026-43499-app.so",
         "size": 104128
       },
       "kernelsu": {
         "url": "https://raw.githubusercontent.com/BuSung-dev/Root-My-Galaxy-Payloads/main/kernelsu/ksud-e3q-S928USQS6DZF2-kdp",
-        "size": 4726416,
-        "kmi": "android14-6.1",
-        "managerPackage": "me.weishu.kernelsu"
+        "size": 4726416
       }
     },
     {
       "payloadId": "essi-A566EXXSCCZG6",
       "displayName": "Galaxy A56 5G | A566EXXSCCZG6",
-      "compatibility": {
-        "manufacturer": "samsung",
-        "supportedDevices": [
-          { "name": "Galaxy A56 5G", "model": "SM-A566E", "region": "International" }
-        ],
-        "kernelRelease": {
-          "exact": ["6.6.102-android15-8-abA566EXXSCCZG6-4k"],
-          "prefix": "",
-          "contains": "",
-          "suffix": ""
-        },
-        "kernelBuildVersions": ["#1 SMP PREEMPT Thu Jul  9 11:02:17 UTC 2026"],
-        "buildDisplays": ["BP4A.251205.006.A566EXXSCCZG6"],
-        "securityPatchMonths": [],
-        "sdk": 36,
-        "abi": "arm64-v8a",
-        "pageSize": 4096
-      },
+      "models": ["SM-A566E"],
+      "builds": ["BP4A.251205.006.A566EXXSCCZG6"],
       "exploit": {
         "url": "https://raw.githubusercontent.com/BuSung-dev/Root-My-Galaxy-Payloads/main/artifacts/essi-A566EXXSCCZG6/cve-2026-43499-app.so",
         "size": 104128
       },
       "kernelsu": {
         "url": "https://raw.githubusercontent.com/BuSung-dev/Root-My-Galaxy-Payloads/main/kernelsu/ksud-A566EXXSCCZG6-kdp",
-        "size": 4765336,
-        "kmi": "android15-6.6",
-        "managerPackage": "me.weishu.kernelsu"
+        "size": 4765336
       }
     }
   ]


### PR DESCRIPTION
## Summary
- flatten `targets-v3.json` to the fields contributors actually provide
- replace regional device objects and kernel metadata with a `models` list
- keep only exact `builds` or verified `securityPatchMonths` as runtime constraints
- remove duplicated KMI, manager package, SDK, ABI, page-size, and kernel-rule fields
- document the minimal contribution format

## Validation
- parsed schema version 3 with 3 payloads
- verified 32 unique S25 model identifiers
- verified every artifact URL maps to a local file with the declared size
- confirmed `targets-v2.json` is unchanged

## Merge order
Merge this before BuSung-dev/Root-My-Galaxy#121 and release both changes together. Released v0.2.3 clients continue to use `targets-v2.json`.