### PR TITLE
Match v3 payloads by model and kernel version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,14 @@ It intentionally does not contain Android application source code.
 
 ## Supported payloads
 
-| Payload | Compatible devices/builds | Kernel/KMI | Status |
+| Payload | Compatible models | Kernel version | Status |
 | --- | --- | --- | --- |
-| `galaxy-s25-series-2026-06-07` | Galaxy S25, S25+, S25 Edge, and S25 Ultra regional models on June/July 2026 security patches | `android15-6.6` / 4K | Device-tested |
-| `e3q-S928USQS6DZF2` | Galaxy S24 Ultra `SM-S928U`, exact `S928USQS6DZF2` build | `6.1.145-android14-11-33419968-abS928USQS6DZF2` | Hardware debugging in progress |
-| `essi-A566EXXSCCZG6` | Galaxy A56 5G `SM-A566E`, exact `A566EXXSCCZG6` build | `6.6.102-android15-8-abA566EXXSCCZG6-4k` | Device-tested |
+| `galaxy-s25-series-2026-06-07` | Galaxy S25, S25+, S25 Edge, and S25 Ultra regional models | `6.6.98` | Device-tested |
+| `e3q-S928USQS6DZF2` | Galaxy S24 Ultra `SM-S928U` | `6.1.145` | Hardware debugging in progress |
+| `essi-A566EXXSCCZG6` | Galaxy A56 5G `SM-A566E` | `6.6.102` | Device-tested |
 
 Schema version 3 keeps each exploit and KernelSU artifact once. Its flat
-`models` array lists compatible regional models, while `builds` or
-`securityPatchMonths` limits the verified firmware range. See
+`models` and `kernelVersions` arrays define runtime compatibility. See
 [`support/README.md`](support/README.md) for the matching rules.
 
 The port is based on the exploit source published at

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -432,13 +432,12 @@ depends on symbols trimmed from the target export table.
 ## 8. Publish the support feed
 
 Add the artifact once to `support/targets-v3.json`, then add every verified
-regional `Build.MODEL` value to `models`. Use `builds` for an exact-build port.
-Use `securityPatchMonths` only after the same artifact has been validated on
-every listed model across that complete month range. Kernel analysis and exact
-`uname` evidence belong in the target source and porting notes, not the runtime
-support manifest. Update artifact sizes, validate the final JSON, and confirm
-that Root My Galaxy can parse it before publishing. The minimal fields are
-documented in [`../support/README.md`](../support/README.md).
+regional `Build.MODEL` value to `models` and the leading three-part `uname -r`
+value to `kernelVersions`. Kernel suffixes and firmware build identifiers stay
+in the target source and porting notes rather than the runtime support
+manifest. Update artifact sizes, validate the final JSON, and confirm that Root
+My Galaxy can parse it before publishing. The minimal fields are documented in
+[`../support/README.md`](../support/README.md).
 
 ## 9. Cleanup policy
 

--- a/support/README.md
+++ b/support/README.md
@@ -1,20 +1,19 @@
 # Support feed schema
 
 `targets-v3.json` keeps one entry for each shared exploit and KernelSU payload.
-`models` lists every model that can use those exact binaries.
+Automatic selection matches the exact device model and three-part kernel
+version, such as `6.6.98`.
 
 Each entry contains only:
 
 - `payloadId` and `displayName`;
 - one or more exact `Build.MODEL` values in `models`;
-- either exact Android build displays in `builds` or verified `YYYY-MM` values
-  in `securityPatchMonths`;
+- one or more versions in `kernelVersions`;
 - `url` and `size` for the exploit and KernelSU artifacts.
 
-Automatic selection requires a model match and all declared build constraints
-to match. Omit `builds` when the payload is validated for every build in the
-listed security-patch months. Omit `securityPatchMonths` for an exact-build
-payload. At least one of these two constraints is required.
+The app extracts the leading numeric version from `uname -r`. Kernel suffixes,
+Android build displays, fingerprints, and security-patch dates do not
+participate in matching.
 
 `targets-v2.json` remains unchanged for released 0.2.3 clients. New clients
 read only schema version 3.

--- a/support/targets-v3.json
+++ b/support/targets-v3.json
@@ -3,7 +3,7 @@
   "payloads": [
     {
       "payloadId": "galaxy-s25-series-2026-06-07",
-      "displayName": "Galaxy S25 series | June/July 2026",
+      "displayName": "Galaxy S25 series | Kernel 6.6.98",
       "models": [
         "SM-S9310",
         "SM-S931B",
@@ -38,7 +38,7 @@
         "SC-52F",
         "SCG32"
       ],
-      "securityPatchMonths": ["2026-06", "2026-07"],
+      "kernelVersions": ["6.6.98"],
       "exploit": {
         "url": "https://raw.githubusercontent.com/BuSung-dev/Root-My-Galaxy-Payloads/main/artifacts/pa3q-S938NKSUACZF1/cve-2026-43499-app.so",
         "size": 104128
@@ -50,9 +50,9 @@
     },
     {
       "payloadId": "e3q-S928USQS6DZF2",
-      "displayName": "Galaxy S24 Ultra | S928USQS6DZF2",
+      "displayName": "Galaxy S24 Ultra | Kernel 6.1.145",
       "models": ["SM-S928U"],
-      "builds": ["BP4A.251205.006.S928USQS6DZF2"],
+      "kernelVersions": ["6.1.145"],
       "exploit": {
         "url": "https://raw.githubusercontent.com/BuSung-dev/Root-My-Galaxy-Payloads/main/artifacts/e3q-S928USQS6DZF2/cve-2026-43499-app.so",
         "size": 104128
@@ -64,9 +64,9 @@
     },
     {
       "payloadId": "essi-A566EXXSCCZG6",
-      "displayName": "Galaxy A56 5G | A566EXXSCCZG6",
+      "displayName": "Galaxy A56 5G | Kernel 6.6.102",
       "models": ["SM-A566E"],
-      "builds": ["BP4A.251205.006.A566EXXSCCZG6"],
+      "kernelVersions": ["6.6.102"],
       "exploit": {
         "url": "https://raw.githubusercontent.com/BuSung-dev/Root-My-Galaxy-Payloads/main/artifacts/essi-A566EXXSCCZG6/cve-2026-43499-app.so",
         "size": 104128


### PR DESCRIPTION
## Summary
- replace build and security-patch constraints in `targets-v3.json` with `kernelVersions`
- match the leading three-part `uname -r` version, such as `6.6.98`
- keep model matching and artifact metadata unchanged
- document the contribution format and matching semantics

## Registered versions
- Galaxy S25 series: `6.6.98`
- Galaxy S24 Ultra SM-S928U: `6.1.145`
- Galaxy A56 SM-A566E: `6.6.102`

## Validation
- parsed all v3 payloads
- verified every payload declares models and kernel versions
- verified artifact sizes
- confirmed build and security-patch fields are absent

## Dependency
Merge together with the Root My Galaxy application PR that reads the updated v3 schema.