### PR TITLE
Add all A56 models to Galaxy A56 payload

### DIFF
--- a/support/targets-v3.json
+++ b/support/targets-v3.json
@@ -65,7 +65,7 @@
     {
       "payloadId": "essi-A566EXXSCCZG6",
       "displayName": "Galaxy A56 5G | Kernel 6.6.102",
-      "models": ["SM-A566E"],
+      "models": ["SM-A5660", "SM-A566B", "SM-A566E", "SM-A566S", "SM-A566U1", "SM-A566W"],
       "kernelVersions": ["6.6.102"],
       "exploit": {
         "url": "https://raw.githubusercontent.com/BuSung-dev/Root-My-Galaxy-Payloads/main/artifacts/essi-A566EXXSCCZG6/cve-2026-43499-app.so",


### PR DESCRIPTION
Adds all of the remaning A56 models to targets-v3.json.