### PR TITLE
Add support for kernel 6.12 in KernelSU patch

### DIFF
--- a/kernelsu/patches/KernelSU-v3.2.5-samsung-kdp-rkp-defex.patch
+++ b/kernelsu/patches/KernelSU-v3.2.5-samsung-kdp-rkp-defex.patch
@@ -1,5 +1,5 @@
 diff --git a/kernel/Kbuild b/kernel/Kbuild
-index fd31bb51..d642c2ca 100644
+index fd31bb51..5afb4d21 100644
 --- a/kernel/Kbuild
 +++ b/kernel/Kbuild
 @@ -1,5 +1,8 @@
@@ -34,7 +34,7 @@ index fd31bb51..d642c2ca 100644
  ccflags-y += -I$(objtree)/security/selinux -include $(srctree)/include/uapi/asm-generic/errno.h
  
  ifeq ($(filter /%,$(src)),)
-@@ -72,7 +85,7 @@ else
+@@ -72,7 +88,7 @@ else
  KSU_KERNEL_DIR := $(src)
  endif
  
@@ -43,8 +43,7 @@ index fd31bb51..d642c2ca 100644
  
  obj-$(CONFIG_KSU) += kernelsu.o
  
-@@ -108,8 +121,10 @@ $(info -- KernelSU version: $(KSU_VERSION))
- ccflags-y += -DKSU_VERSION=$(KSU_VERSION)
+@@ -109,7 +125,9 @@ ccflags-y += -DKSU_VERSION=$(KSU_VERSION)
  else
  # If there is no .git directory, use default version
  $(warning "KSU_GIT_VERSION not defined! It is better to make KernelSU a git repository!")
@@ -175,10 +174,10 @@ index 00000000..f635af65
 +#endif
 diff --git a/kernel/compat/samsung_kdp.c b/kernel/compat/samsung_kdp.c
 new file mode 100644
-index 00000000..ec853153
+index 00000000..b882f099
 --- /dev/null
 +++ b/kernel/compat/samsung_kdp.c
-@@ -0,0 +1,178 @@
+@@ -0,0 +1,204 @@
 +#include <linux/completion.h>
 +#include <linux/cred.h>
 +#include <linux/errno.h>
@@ -189,6 +188,7 @@ index 00000000..ec853153
 +#include <linux/user_namespace.h>
 +#include <linux/version.h>
 +#include <linux/workqueue.h>
++#include <linux/pid.h>
 +
 +#include "infra/symbol_resolver.h"
 +#include "ksu_samsung_kdp.h"
@@ -201,7 +201,11 @@ index 00000000..ec853153
 +
 +typedef struct cred *(*prepare_ro_creds_t)(struct cred *cred, int command, u64 task);
 +typedef void (*kdp_assign_pgd_t)(struct task_struct *task);
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
++typedef unsigned int (*kdp_usecount_sub_and_test_t)(int nr, struct cred *cred);
++#else
 +typedef unsigned int (*kdp_usecount_dec_and_test_t)(struct cred *cred);
++#endif
 +#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0)
 +typedef long (*inc_rlimit_ucounts_t)(struct ucounts *ucounts, enum rlimit_type type, long value);
 +typedef bool (*dec_rlimit_ucounts_t)(struct ucounts *ucounts, enum rlimit_type type, long value);
@@ -218,7 +222,11 @@ index 00000000..ec853153
 +
 +static prepare_ro_creds_t prepare_ro_creds_fn;
 +static kdp_assign_pgd_t kdp_assign_pgd_fn;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
++static kdp_usecount_sub_and_test_t kdp_usecount_sub_and_test_fn;
++#else
 +static kdp_usecount_dec_and_test_t kdp_usecount_dec_and_test_fn;
++#endif
 +#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0)
 +static inc_rlimit_ucounts_t inc_rlimit_ucounts_fn;
 +static dec_rlimit_ucounts_t dec_rlimit_ucounts_fn;
@@ -291,7 +299,11 @@ index 00000000..ec853153
 +#ifdef CONFIG_KSU_SAMSUNG_KDP
 +    struct cred *mutable_cred = (struct cred *)cred;
 +
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
++    if (mutable_cred && kdp_usecount_sub_and_test_fn(1, mutable_cred))
++#else
 +    if (mutable_cred && kdp_usecount_dec_and_test_fn(mutable_cred))
++#endif
 +        __put_cred(mutable_cred);
 +#else
 +    put_cred(cred);
@@ -303,12 +315,25 @@ index 00000000..ec853153
 +#ifdef CONFIG_KSU_SAMSUNG_KDP
 +    prepare_ro_creds_fn = (prepare_ro_creds_t)ksu_resolve_symbol_for_functable_hook("prepare_ro_creds");
 +    kdp_assign_pgd_fn = (kdp_assign_pgd_t)ksu_resolve_symbol_for_functable_hook("kdp_assign_pgd");
-+    kdp_usecount_dec_and_test_fn = (kdp_usecount_dec_and_test_t)ksu_resolve_symbol_for_functable_hook(
-+        "kdp_usecount_dec_and_test");
-+    if (!prepare_ro_creds_fn || !kdp_assign_pgd_fn || !kdp_usecount_dec_and_test_fn) {
++    if (!prepare_ro_creds_fn || !kdp_assign_pgd_fn) {
 +        pr_err("Samsung KDP credential functions unavailable\n");
 +        return -ENOENT;
 +    }
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
++    kdp_usecount_sub_and_test_fn = (kdp_usecount_sub_and_test_t)ksu_resolve_symbol_for_functable_hook(
++        "kdp_usecount_sub_and_test");
++    if (!kdp_usecount_sub_and_test_fn) {
++        pr_err("Samsung KDP credential functions unavailable\n");
++        return -ENOENT;
++    }
++#else
++    kdp_usecount_dec_and_test_fn = (kdp_usecount_dec_and_test_t)ksu_resolve_symbol_for_functable_hook(
++        "kdp_usecount_dec_and_test");
++    if (!kdp_usecount_dec_and_test_fn) {
++        pr_err("Samsung KDP credential functions unavailable\n");
++        return -ENOENT;
++    }
++#endif
 +#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0)
 +    inc_rlimit_ucounts_fn = (inc_rlimit_ucounts_t)ksu_resolve_symbol_for_functable_hook("inc_rlimit_ucounts");
 +    dec_rlimit_ucounts_fn = (dec_rlimit_ucounts_t)ksu_resolve_symbol_for_functable_hook("dec_rlimit_ucounts");


### PR DESCRIPTION
Update KernelSU patch for 6.12.

In 6.12, kdp_usecount_dec_and_test was removed and kdp_usecount_sub_and_test_fn was introduced.
Patch file was created by the following commit:
https://github.com/polygraphene/KernelSU/commit/a5531763971cf034e3f630d31654189a148e5f81

Tested on Galaxy S26 6.12.30-android16-5-pe553c2c-abogkiS942QOPU1AZDE-4k

To launch ksud, I used my fork of the original exploit.
https://github.com/polygraphene/CyberMeowfia

I want to send PR for the payload later, but it might take time to integrate into Root My Galaxy.
If anyone want to integrate my fork on my behalf, that would be welcome.